### PR TITLE
Hide old items from public

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -81,6 +81,13 @@ const fetchAndSetItems = async () => {
       .select('*')
       .order('created_at', { ascending: false });
 
+    // Hide items older than 45 days for non-admin users
+    if (!user) {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - 45);
+      query = query.gte('created_at', cutoff.toISOString());
+    }
+
     if (filters.searchQuery) {
       query = query.or(`name.ilike.%${filters.searchQuery}%,description.ilike.%${filters.searchQuery}%`);
     }
@@ -144,6 +151,13 @@ fetchAndSetItems();
           .select('*')
           .order('created_at', { ascending: false });
 
+        // Hide items older than 45 days for non-admin users
+        if (!user) {
+          const cutoff = new Date();
+          cutoff.setDate(cutoff.getDate() - 45);
+          query = query.gte('created_at', cutoff.toISOString());
+        }
+
         if (filters.searchQuery) {
           query = query.or(`name.ilike.%${filters.searchQuery}%,description.ilike.%${filters.searchQuery}%`);
         }
@@ -188,9 +202,18 @@ fetchAndSetItems();
   const fetchTags = async () => {
     try {
       setError(null);
-      const { data, error: fetchError } = await supabase
+      let query = supabase
         .from('items')
         .select('tags');
+
+      // Hide tags from items older than 45 days for non-admin users
+      if (!user) {
+        const cutoff = new Date();
+        cutoff.setDate(cutoff.getDate() - 45);
+        query = query.gte('created_at', cutoff.toISOString());
+      }
+
+      const { data, error: fetchError } = await query;
 
       if (fetchError) throw fetchError;
       

--- a/src/components/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage.tsx
@@ -25,11 +25,19 @@ export function ItemDetailPage() {
       
       try {
         setLoading(true);
-        const { data, error } = await supabase
+        let query = supabase
           .from('items')
           .select('*')
-          .eq('id', id)
-          .single();
+          .eq('id', id);
+
+        // Hide items older than 45 days for non-admin users
+        if (!user) {
+          const cutoff = new Date();
+          cutoff.setDate(cutoff.getDate() - 45);
+          query = query.gte('created_at', cutoff.toISOString());
+        }
+
+        const { data, error } = await query.single();
 
         if (error) throw error;
         setItem(data);


### PR DESCRIPTION
## Summary
- restrict public queries to items from last 45 days
- apply same check when fetching tags
- block direct access to outdated items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68487d54e41083288c95e9154b1966be

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts unauthenticated users to viewing items (and tags) from the past 45 days, including direct item access.
> 
> - **Visibility restriction (public)**:
>   - In `src/components/HomePage.tsx`:
>     - Apply 45-day `created_at` cutoff for unauthenticated users to item queries (initial fetch and GA-triggered fetch).
>     - Apply the same cutoff when fetching `tags`.
>   - In `src/components/ItemDetailPage.tsx`:
>     - Enforce 45-day cutoff when fetching a single item by `id`.
> - **Query construction**:
>   - Refactor queries to use a mutable `query` with conditional `.gte('created_at', ...)` before execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 872de756edae66b243c417acf8511fc23fb0794d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->