### PR TITLE
Admin dashboard, 60-day public retention, claim flow & filtering fixes

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,52 @@
+# Lost & Found 2.0 — Change Summary
+
+## Overview
+This update introduces an admin workflow for claim tracking, enforces 60-day public item visibility, and fixes item filtering behavior so filters apply correctly in the public listing.
+
+## Features Added
+
+### 1) Admin-only dashboard (`/admin`)
+- Added a protected admin route in the app router.
+- Created a new **Admin Dashboard** page with:
+  - **Claims table** (claimant, claimant type, item, claimed timestamp)
+  - **Admin item search** table (includes items hidden from public after retention window)
+- Added Admin navigation button in desktop and mobile nav for admin users only.
+
+### 2) Claim flow improvements
+- Claim submission records claimant data including claimant type and related fields.
+- Claim submission still marks item as claimed.
+- Success state continues to display pickup instructions.
+- Improved error handling typing and messaging in the claim form.
+
+### 3) Public retention policy (60 days)
+- Added a shared helper for retention checks (`isExpiredItem`).
+- Public-facing item visibility is constrained to the latest 60 days.
+- Admin users can still search and view older/expired items in admin tools.
+
+### 4) Filtering fix on homepage
+- Reworked fetch/filter logic so item queries rerun when filters change.
+- Updated tag matching logic to **overlap** selected tags (any match), improving expected behavior.
+- Preserved support for search text, category, claim status, and date-range filtering.
+
+## Database / Supabase Changes
+Added migration:
+- `supabase/migrations/20260415093000_admin_claims_and_retention.sql`
+
+Migration responsibilities:
+- Adds missing claim columns (`claimant_type`, `division`)
+- Adds `is_admin` to `staff_emails`
+- Adds `public.is_admin_user()` helper function
+- Restricts claim read access to admins
+- Limits public item reads to last 60 days
+- Allows admins to read all items
+- Adds supporting indexes
+
+## Type Updates
+Updated shared database types to include:
+- `claimantType` and `division` on claim form data
+- `claimant_type` and `division` on claim records
+
+## Notes for Deployment
+- Apply the new Supabase migration before release.
+- Ensure real admin accounts have `staff_emails.is_admin = true`.
+- Replace any placeholder seeded admin email (e.g. `admin@example.com`) with real admin email(s).


### PR DESCRIPTION
### Motivation
- Add admin tooling for tracking and managing claims and allow admins to view items beyond the public retention window.
- Enforce a 60-day public retention policy so public listings only show recent items while preserving admin access to older items.
- Improve the claim submission flow to capture claimant metadata and improve error handling.
- Fix homepage filtering so tag and other filters properly trigger new queries and return expected results.

### Description
- Added a protected admin route and an Admin Dashboard with a Claims table and an Admin item search that includes expired/hidden items. 
- Implemented claim flow changes to record `claimant_type` and `division` on submissions and updated shared DB types accordingly. 
- Introduced a shared `isExpiredItem` retention helper and constrained public item queries to the latest 60 days while allowing admins to read all items. 
- Reworked fetch/filter logic so item queries rerun when filters change and changed tag matching to use overlap (any selected tag match). 
- Added a Supabase migration `supabase/migrations/20260415093000_admin_claims_and_retention.sql` to add claim columns, `is_admin` to `staff_emails`, a `public.is_admin_user()` helper, read restrictions, and supporting indexes. 

### Testing
- Ran unit tests with `npm test` and TypeScript checks with `tsc --noEmit`, and both completed successfully. 
- Ran the build with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df323e0d7083288255f1b68bf49018)